### PR TITLE
Adding a cache for the trusted advisor collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added caching to trusted advisor collector to reduce API call load.
+
 ## [1.0.0] - 2020-09-04
 
 ### Added

--- a/service/collector/trusted_advisor.go
+++ b/service/collector/trusted_advisor.go
@@ -219,7 +219,7 @@ func (t *TrustedAdvisor) collectForAccount(ch chan<- prometheus.Metric, awsClien
 	}
 
 	//Cache empty, getting from API
-	if trustedAdvisorInfo == nil || trustedAdvisorInfo.trustedAdvisors == nil {
+	if trustedAdvisorInfo == nil || trustedAdvisorInfo.TrustedAdvisors == nil {
 		trustedAdvisorInfo, err = t.getTrustedAdvisorInfoFromAPI(accountID, awsClients)
 		if err != nil {
 			return microerror.Mask(err)
@@ -232,7 +232,7 @@ func (t *TrustedAdvisor) collectForAccount(ch chan<- prometheus.Metric, awsClien
 		}
 	}
 	if trustedAdvisorInfo != nil {
-		for _, ta := range trustedAdvisorInfo.trustedAdvisors {
+		for _, ta := range trustedAdvisorInfo.TrustedAdvisors {
 
 			for _, resource := range ta.Resources {
 				limit, usage, err := resourceToMetrics(resource, accountID)
@@ -317,7 +317,7 @@ func (t *TrustedAdvisor) getTrustedAdvisorInfoFromAPI(accountID string, awsClien
 			return nil, microerror.Mask(err)
 		}
 	}
-	res.trustedAdvisors = trustedAdvisors
+	res.TrustedAdvisors = trustedAdvisors
 	return &res, nil
 }
 

--- a/service/collector/trusted_advisor.go
+++ b/service/collector/trusted_advisor.go
@@ -96,7 +96,7 @@ type trustedAdvisorCache struct {
 }
 
 type trustedAdvisorInfoResponse struct {
-	trustedAdvisors []trustedAdvisorInfo
+	TrustedAdvisors []trustedAdvisorInfo
 }
 
 type trustedAdvisorInfo struct {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13192 and related PM

Our collector makes a lot of calls to the trusted advisor API. This introduces a cache.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
