### PR TITLE
Add subnet type to subnet collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add subnet type for subnet collector.
+
 ## [1.2.0] - 2021-06-18
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/viper v1.8.1
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.18.19
 	k8s.io/apimachinery v0.18.19
@@ -25,6 +26,7 @@ require (
 replace (
 	github.com/coreos/etcd v3.3.10+incompatible => github.com/coreos/etcd v3.3.25+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible => github.com/coreos/etcd v3.3.25+incompatible
+	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
 	sigs.k8s.io/cluster-api => github.com/giantswarm/cluster-api v0.3.13-gs
 )

--- a/go.sum
+++ b/go.sum
@@ -150,7 +150,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -829,8 +829,9 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
+golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/service/collector/subnet.go
+++ b/service/collector/subnet.go
@@ -38,11 +38,11 @@ var (
 			labelInstallation,
 			labelOrganization,
 			labelStack,
+			labelSubnetType,
 			labelState,
 			labelAvailabilityZone,
 			labelAccount,
 			labelVPC,
-			labelSubnetType,
 		},
 		nil,
 	)
@@ -216,11 +216,11 @@ func (e *Subnet) collectForAccount(ctx context.Context, ch chan<- prometheus.Met
 				e.installationName,
 				subnet.Tags[key.TagOrganization],
 				subnet.Tags[key.TagStack],
+				subnet.Tags[key.TagSubnetType],
 				subnet.Tags["State"],
 				subnet.Tags["AvailabilityZone"],
 				subnet.Tags["OwnerId"],
 				subnet.Tags["VpcId"],
-				subnet.Tags[key.TagSubnetType],
 			)
 		}
 	}

--- a/service/collector/subnet.go
+++ b/service/collector/subnet.go
@@ -23,6 +23,7 @@ const (
 
 const (
 	subsystemSubnet = "subnet"
+	labelSubnetType = "subnet_type"
 )
 
 var (
@@ -219,6 +220,7 @@ func (e *Subnet) collectForAccount(ctx context.Context, ch chan<- prometheus.Met
 				subnet.Tags["AvailabilityZone"],
 				subnet.Tags["OwnerId"],
 				subnet.Tags["VpcId"],
+				subnet.Tags[key.TagSubnetType],
 			)
 		}
 	}

--- a/service/collector/subnet.go
+++ b/service/collector/subnet.go
@@ -41,6 +41,7 @@ var (
 			labelAvailabilityZone,
 			labelAccount,
 			labelVPC,
+			labelSubnetType,
 		},
 		nil,
 	)

--- a/service/collector/vpc.go
+++ b/service/collector/vpc.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	labelCIDR  = "cidr"
-	labelID    = "id"
-	labelStack = "stack_name"
-	labelState = "state"
+	labelCIDR       = "cidr"
+	labelID         = "id"
+	labelStack      = "stack_name"
+	labelState      = "state"
+	labelSubnetType = "subnet_type"
 )
 
 const (
@@ -38,6 +39,7 @@ var (
 			labelOrganization,
 			labelStack,
 			labelState,
+			labelSubnetType,
 		},
 		nil,
 	)
@@ -130,7 +132,7 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 	}
 
 	for _, vpc := range o.Vpcs {
-		var cluster, installation, name, organization, stackName string
+		var cluster, installation, name, organization, stackName, subnetType string
 
 		for _, tag := range vpc.Tags {
 			switch *tag.Key {
@@ -144,6 +146,8 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 				organization = *tag.Value
 			case tagStackName:
 				stackName = *tag.Value
+			case key.TagSubnetType:
+				subnetType = *tag.Value
 			}
 		}
 
@@ -164,6 +168,7 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 			organization,
 			stackName,
 			*vpc.State,
+			subnetType,
 		)
 	}
 

--- a/service/collector/vpc.go
+++ b/service/collector/vpc.go
@@ -14,11 +14,10 @@ import (
 )
 
 const (
-	labelCIDR       = "cidr"
-	labelID         = "id"
-	labelStack      = "stack_name"
-	labelState      = "state"
-	labelSubnetType = "subnet_type"
+	labelCIDR  = "cidr"
+	labelID    = "id"
+	labelStack = "stack_name"
+	labelState = "state"
 )
 
 const (
@@ -39,7 +38,6 @@ var (
 			labelOrganization,
 			labelStack,
 			labelState,
-			labelSubnetType,
 		},
 		nil,
 	)
@@ -132,7 +130,7 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 	}
 
 	for _, vpc := range o.Vpcs {
-		var cluster, installation, name, organization, stackName, subnetType string
+		var cluster, installation, name, organization, stackName string
 
 		for _, tag := range vpc.Tags {
 			switch *tag.Key {
@@ -146,8 +144,6 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 				organization = *tag.Value
 			case tagStackName:
 				stackName = *tag.Value
-			case key.TagSubnetType:
-				subnetType = *tag.Value
 			}
 		}
 
@@ -168,7 +164,6 @@ func (v *VPC) collectForAccount(ch chan<- prometheus.Metric, awsClients clientaw
 			organization,
 			stackName,
 			*vpc.State,
-			subnetType,
 		)
 	}
 


### PR DESCRIPTION
This will include additional information around subnet type to potentially alarm us on IP exhaustion for CNI network:

giantswarm.io/subnet-type
  - private
  - aws-cni

## Checklist

- [x] Update changelog in CHANGELOG.md.