### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.33.0
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
@@ -30,38 +30,18 @@ workflows:
 
       # Ensure that for every commit (all branches), and for every new release tag,
       # an image is pushed to Quay.
-      - architect/push-to-docker:
-          name: push-to-quay
+      - architect/push-to-registries:
           context: architect
-          image: "quay.io/giantswarm/aws-collector"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+          name: push-to-registries
           requires:
             - go-build
+            - hold-push-to-aliyun-pr
           filters:
             tags:
               only: /^v.*/
 
       # Ensure that for every commit to master, and for every new release tag,
       # an image gets pushed to the Aliyun registry.
-      - architect/push-to-docker:
-          name: push-to-aliyun
-          context: architect
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/aws-collector"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - go-build
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^v.*/
-
-      # Allow that for every commit (to a branch other than master),
-      # and for every new tag that is not a release tag,
-      # an image _can_ get pushed to the Aliyun registry
-      # if manually approved.
       - hold-push-to-aliyun-pr:
           type: approval
           requires:
@@ -71,22 +51,6 @@ workflows:
               ignore: master
             tags:
               ignore: /^v.*/
-      - architect/push-to-docker:
-          name: push-to-aliyun-pr
-          context: architect
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/aws-collector"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - hold-push-to-aliyun-pr
-          filters:
-            branches:
-              ignore: master
-            tags:
-              ignore: /.*/
-
-      # Ensure that for every commit to master and for every
-      # release tag, there is an app version in the catalog.
       - architect/push-to-app-catalog:
           name: push-to-app-catalog-master
           context: architect
@@ -94,8 +58,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-collector"
           requires:
-            - push-to-aliyun
-            - push-to-quay
+            - push-to-registries
           filters:
             branches:
               only: master
@@ -113,7 +76,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "aws-collector"
           requires:
-            - push-to-quay
+            - push-to-registries
           filters:
             branches:
               ignore: master


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!