### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `PolicyExceptions` to `v2` and failover to `v2beta1`.
+
 ## [2.4.0] - 2024-03-26
 
 ### Added

--- a/helm/aws-collector/templates/pss-exceptions.yaml
+++ b/helm/aws-collector/templates/pss-exceptions.yaml
@@ -1,4 +1,10 @@
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" }}
+apiVersion: kyverno.io/v2
+{{- else if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" }}
 apiVersion: kyverno.io/v2beta1
+{{- else }}
+apiVersion: kyverno.io/v2alpha1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ include "resource.default.name" . }}-exceptions

--- a/helm/aws-collector/templates/pss-exceptions.yaml
+++ b/helm/aws-collector/templates/pss-exceptions.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "resource.default.name" . }}-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.